### PR TITLE
manureRecyclingProductCategory name fix

### DIFF
--- a/src/eCH-0263-1-0.xsd
+++ b/src/eCH-0263-1-0.xsd
@@ -139,7 +139,7 @@ Datum				Version				Autor
 					<xs:documentation xml:lang="de">Beschreibung</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="manureRecycling-ProductCategory">
+			<xs:element name="manureRecyclingProductCategory">
 				<xs:annotation>
 					<xs:documentation xml:lang="de">Hof- und Recyclingdünger-Produktkategorie</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
This makes the name of this attribute consistent with the rest of the standards (and with the documentation)