### PR TITLE
Ingredient quantity to 3 digits

### DIFF
--- a/src/eCH-0263-1-0.xsd
+++ b/src/eCH-0263-1-0.xsd
@@ -618,7 +618,7 @@ Dichte in kg/m3, falls «kg» als Transaktionseinheit (transactionUnit) des übe
 				</xs:annotation>
 				<xs:simpleType>
 					<xs:restriction base="xs:decimal">
-						<xs:fractionDigits value="2"/>
+						<xs:fractionDigits value="3"/>
 					</xs:restriction>
 				</xs:simpleType>
 			</xs:element>


### PR DESCRIPTION
Fixes #8 

I honestly to not see any issue in defining it as 3 digits if an impostant stakeholder has this requirement. Worst case, the 2-digits systems either pad it with a 0 (when sending) or round it (when receiving)