### PR TITLE
add xs:import namespace eCH-0266

### DIFF
--- a/src/eCH-0263-1-0.xsd
+++ b/src/eCH-0263-1-0.xsd
@@ -32,7 +32,7 @@ Datum				Version				Autor
 			</xs:element>
 			<xs:element name="admissonType">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Zuslassungsart</xs:documentation>
+					<xs:documentation xml:lang="de">Zulassungsart</xs:documentation>
 				</xs:annotation>
 				<xs:simpleType>
 					<xs:restriction base="xs:token">


### PR DESCRIPTION
tl;dr
if applicable: 
- add namespace 0266
- refer to correct datatype
- change annotation to "zoologicalAnimal"


add <xs:import namespace="http://www.ech.ch/xmlns/eCH-0266/1" schemaLocation="http://www.ech.ch/xmlns/eCH-0266/1/eCH-0266-1-0.xsd"/> as 0266 is mentioned in the 3 annotations: 

<xs:complexType name="feedstuffType">
		<xs:sequence>
			<xs:element name="intendedForAnimal" minOccurs="0" maxOccurs="unbounded">
				<xs:annotation>
					<xs:documentation xml:lang="de">Erlaubte Tierkategorien Referenziert einen Code einer Spezies, welcher durch «taxonomySpecies» aus eCH-0266 definiert wird.</...>

<xs:complexType name="manureDerivationType">
		<xs:sequence>
			<xs:element name="animalOrPlant-Source">
				<xs:annotation>
					<xs:documentation xml:lang="de">Angabe eines Tiers (Code einer Spezies, welcher durch «taxonomySpecies» aus eCH-0266 definiert wird), falls der Mist tie-rischer Herkunft ist. Ansonsten wird der String «NON_ANIMAL» angegeben.</xs:documentation>
				</...>

<xs:complexType name="manureDerivationType">
		<xs:sequence>
			<xs:element name="utlisation" minOccurs="0" maxOccurs="unbounded">
				<xs:annotation>
					<xs:documentation xml:lang="de">Verwendungszweck (Code einer Nutzungsausrichtung, welche durch «utilisation» aus eCH-0266 definiert ist).</xs:documentation>
				</xs:annotation></...>


Change elements accordingly, and refer to correct datatype. 

!!!  I could not find taxonomySpecies in 0266. Perhaps it was changed to "zoologicalAnimal"? !!!